### PR TITLE
Added github actions CI

### DIFF
--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -16,6 +16,15 @@ jobs:
     steps:
       - name: Checkout sources
         uses: actions/checkout@v2
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - name: Install stable toolchain
         uses: actions-rs/toolchain@v1
         with:
@@ -47,6 +56,15 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v2
+      - name: Cache dependencies
+        id: cache-dependencies
+        uses: actions/cache@v2
+        with:
+          path: |
+            ~/.cargo/registry
+            ~/.cargo/git
+            target
+          key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
       - uses: actions-rs/toolchain@v1
         with:
           toolchain: stable

--- a/.github/workflows/general.yaml
+++ b/.github/workflows/general.yaml
@@ -1,0 +1,61 @@
+name: general
+
+on:
+  push:
+    branches:
+      - main
+  pull_request:
+    types: [ opened, synchronize, reopened ]
+    branches:
+      - main
+
+jobs:
+  build:
+    name: build
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout sources
+        uses: actions/checkout@v2
+      - name: Install stable toolchain
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv7em-none-eabihf
+          override: true
+      - name: Install cargo-make    
+        uses: davidB/rust-cargo-make@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: build
+  fmt:
+    name: fmt
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          override: true
+          components: rustfmt
+      - uses: actions-rs/cargo@v1
+        with:
+          command: fmt
+          args: --all -- --check
+  clippy:
+    name: clippy
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          target: thumbv7em-none-eabihf
+          override: true
+          components: clippy
+      - uses: davidB/rust-cargo-make@v1
+      - uses: actions-rs/cargo@v1
+        with:
+          command: make
+          args: clippy -- -D warnings
+

--- a/Makefile.toml
+++ b/Makefile.toml
@@ -1,0 +1,7 @@
+[env]
+CARGO_MAKE_EXTEND_WORKSPACE_MAKEFILE = true
+DEFMT_LOG="info"
+
+[tasks.clippy]
+command = "cargo"
+args = ["clippy", "${@}"]

--- a/README.md
+++ b/README.md
@@ -1,19 +1,24 @@
 # CanSat
-## Prerequisites
- 1. You will need **libusb** <br>
- check out [cargo-embed](https://crates.io/crates/cargo-embed) for instructions
- 2. Add your board target:
-```
-rustup target add thumbv7em-none-eabihf
-```
+Software for the sounding rocket payload.
 
-## Setup
+## Prerequisites
+* [cargo-make](https://github.com/sagiegurari/cargo-make) - Requires `libusb`, see `cargo-make`'s `README.md` for instructions.
+* [cargo-embed](https://github.com/probe-rs/cargo-embed)
+* `thumbv7em-none-eabihf` platform target
 ```
-cargo install cargo-embed
+cargo install cargo-make cargo-embed
+rustup target add thumbv7em-none-eabihf
 ```
 
 ## Run
 ```
 cd cansat-stm32f446
-cargo embed
+cargo make embed
 ```
+
+## Log filters
+You can specify log levels using `DEFMT_LOG` environment variable.
+```
+cargo make --env DEFMT_LOG=debug embed
+```
+See https://defmt.ferrous-systems.com/filtering.html for details.

--- a/cansat-stm32f446/Makefile.toml
+++ b/cansat-stm32f446/Makefile.toml
@@ -1,0 +1,5 @@
+extend = "../Makefile.toml"
+
+[tasks.embed]
+command = "cargo"
+args = ["embed"]

--- a/cansat-stm32f446/build.rs
+++ b/cansat-stm32f446/build.rs
@@ -6,7 +6,7 @@ use std::path::PathBuf;
 fn main() {
     let out_path = PathBuf::from(env::var_os("OUT_DIR").unwrap());
     let linker_script_path = out_path.join("memory.x");
-    File::create(&linker_script_path)
+    File::create(linker_script_path)
         .unwrap()
         .write_all(include_bytes!("memory.x"))
         .unwrap();

--- a/cansat-stm32f446/src/main.rs
+++ b/cansat-stm32f446/src/main.rs
@@ -30,7 +30,7 @@ mod app {
 
     #[idle]
     fn idle(_: idle::Context) -> ! {
-        #[warn(clippy::empty_loop)]
+        #[allow(clippy::empty_loop)]
         loop {}
     }
 }


### PR DESCRIPTION
closes #2 

# Design Notes
* This PR adds a CI that builds, formats, and lints the code for every PR.
* It leverages `cargo-make` crate to allow building all the crates from workspace root. `cargo make build` changes directories before building particular crates, so it uses their `.cargo/config.toml`, as opposed to `cargo build`.
* I also added a new `cargo-make` task called `embed` to `cansat-stm32f446` crate that runs `cargo embed`, but changes the default log level to `info`.