### PR TITLE
Added cansat-gps package

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -58,10 +58,19 @@ dependencies = [
 ]
 
 [[package]]
+name = "cansat-gps"
+version = "0.1.0"
+dependencies = [
+ "embedded-hal 1.0.0-alpha.8",
+ "heapless",
+]
+
+[[package]]
 name = "cansat-stm32f446"
 version = "0.1.0"
 dependencies = [
  "cansat",
+ "cansat-gps",
  "cortex-m",
  "cortex-m-rt",
  "cortex-m-rtic",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,5 +1,6 @@
 [workspace]
 members = [
     "cansat",
+    "cansat-gps",
     "cansat-stm32f446"
 ]

--- a/cansat-gps/Cargo.toml
+++ b/cansat-gps/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "cansat-gps"
+version = "0.1.0"
+edition = "2021"
+
+# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
+
+[dependencies]
+embedded-hal = "1.0.0-alpha.8"
+heapless = { version = "0.7.16", default-features = false }

--- a/cansat-gps/src/lib.rs
+++ b/cansat-gps/src/lib.rs
@@ -1,0 +1,82 @@
+//! Gps device driver.
+//!
+//! It implements double buffering to ensure that you can always read latest message.
+#![deny(unsafe_code)]
+#![no_std]
+
+use core::fmt::Debug;
+use embedded_hal::{
+    nb,
+    serial::{self, nb::Read},
+};
+use heapless::Vec;
+
+pub struct Gps<Uart> {
+    uart: Uart,
+    buf_1: Vec<u8, 512>,
+    buf_2: Vec<u8, 512>,
+    last_msg_location: LastMsgLocation,
+}
+
+enum LastMsgLocation {
+    None,
+    Buf1,
+    Buf2,
+}
+
+#[derive(Debug)]
+pub enum Error<UartError>
+where
+    UartError: serial::Error,
+{
+    Uart(UartError),
+    Overflow(u8),
+}
+
+impl<Uart> Gps<Uart> {
+    pub fn new(uart: Uart) -> Self {
+        Self {
+            uart,
+            buf_1: Vec::new(),
+            buf_2: Vec::new(),
+            last_msg_location: LastMsgLocation::None,
+        }
+    }
+
+    /// Reads last received NMEA message.
+    pub fn last_nmea(&self) -> Option<Vec<u8, 512>> {
+        match self.last_msg_location {
+            LastMsgLocation::Buf1 => Some(self.buf_1.clone()),
+            LastMsgLocation::Buf2 => Some(self.buf_2.clone()),
+            LastMsgLocation::None => None,
+        }
+    }
+}
+
+impl<Uart> Gps<Uart>
+where
+    Uart: Read,
+{
+    /// Reads a single character from UART and stores it in an internal buffer.
+    /// On success, returns the read character.
+    pub fn read_uart(&mut self) -> Result<u8, Error<Uart::Error>> {
+        let b = nb::block!(self.uart.read()).map_err(Error::Uart)?;
+        match self.last_msg_location {
+            LastMsgLocation::Buf1 => {
+                self.buf_2.push(b).map_err(Error::Overflow)?;
+                if b == b'\n' {
+                    self.last_msg_location = LastMsgLocation::Buf2;
+                    self.buf_1.clear();
+                }
+            }
+            LastMsgLocation::Buf2 | LastMsgLocation::None => {
+                self.buf_1.push(b).map_err(Error::Overflow)?;
+                if b == b'\n' {
+                    self.last_msg_location = LastMsgLocation::Buf1;
+                    self.buf_2.clear();
+                }
+            }
+        }
+        Ok(b)
+    }
+}

--- a/cansat-stm32f446/Cargo.toml
+++ b/cansat-stm32f446/Cargo.toml
@@ -7,6 +7,7 @@ edition = "2021"
 
 [dependencies]
 cansat = { path = "../cansat" }
+cansat-gps = { path = "../cansat-gps" }
 cortex-m = { version = "0.7.6", features = ["critical-section-single-core"] }
 cortex-m-rt = "0.7.2"
 cortex-m-rtic = "1.1.3"

--- a/cansat-stm32f446/src/main.rs
+++ b/cansat-stm32f446/src/main.rs
@@ -95,8 +95,8 @@ mod app {
     #[task(binds = USART3, shared = [gps])]
     fn gps_irq(ctx: gps_irq::Context) {
         let mut gps = ctx.shared.gps;
-        let b = gps.lock(|gps| gps.read_uart()).unwrap();
-        if b == b'\n' {
+        let (_, is_terminator) = gps.lock(|gps| gps.read_uart()).unwrap();
+        if is_terminator {
             log_nmea::spawn().unwrap();
         }
     }

--- a/cansat-stm32f446/src/main.rs
+++ b/cansat-stm32f446/src/main.rs
@@ -8,33 +8,33 @@ use panic_probe as _;
 #[rtic::app(device = stm32f4xx_hal::pac, dispatchers = [EXTI0])]
 mod app {
     use cansat::defmt;
-    use heapless::{
-        spsc::{Consumer, Producer, Queue},
-        Vec,
-    };
+    use cansat_gps::Gps;
     use stm32f4xx_hal::{
-        gpio::{Output, PA5},
-        pac::{self, USART3},
+        gpio::{Alternate, Output, PA5, PC10, PC11},
+        pac::{self, TIM3},
         prelude::*,
-        serial,
-        timer::monotonic::MonoTimerUs,
+        serial::{self, Event, Serial3},
+        timer::{monotonic::MonoTimerUs, DelayUs},
     };
 
+    type Rx3 = PC10<Alternate<7>>;
+    type Tx3 = PC11<Alternate<7>>;
+
     #[shared]
-    struct Shared {}
+    struct Shared {
+        gps: Gps<Serial3<(Rx3, Tx3)>>,
+    }
 
     #[local]
     struct Local {
-        gps_rx: serial::Rx<USART3>,
-        gps_buf_prod: Producer<'static, u8, 512>,
-        gps_buf_cons: Consumer<'static, u8, 512>,
+        delay: DelayUs<TIM3>,
         led: PA5<Output>,
     }
 
     #[monotonic(binds = TIM2, default = true)]
     type MicrosecMono = MonoTimerUs<pac::TIM2>;
 
-    #[init(local = [gps_buf: Queue<u8, 512> = Queue::new()])]
+    #[init]
     fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
         defmt::info!("Initializing");
 
@@ -42,67 +42,63 @@ mod app {
         let rcc = device.RCC.constrain();
         let clocks = rcc.cfgr.sysclk(84.MHz()).freeze();
         let mono = device.TIM2.monotonic_us(&clocks);
+        let delay = device.TIM3.delay_us(&clocks);
 
         let gpioa = device.GPIOA.split();
+        let gpioc = device.GPIOC.split();
+
         let led = gpioa.pa5.into_push_pull_output();
 
-        let gpioc = device.GPIOC.split();
-        let usart3_tx_pin = gpioc.pc10.into_alternate();
-        let usart3_rx_pin = gpioc.pc11.into_alternate();
+        let gps = {
+            let usart3_tx_pin = gpioc.pc10.into_alternate();
+            let usart3_rx_pin = gpioc.pc11.into_alternate();
+            let mut gps_serial = device
+                .USART3
+                .serial(
+                    (usart3_tx_pin, usart3_rx_pin),
+                    serial::Config::default().baudrate(9600.bps()),
+                    &clocks,
+                )
+                .expect("Failed to setup usart3");
+            gps_serial.listen(Event::Rxne);
+            Gps::new(gps_serial)
+        };
 
-        let gps_serial = device
-            .USART3
-            .serial(
-                (usart3_tx_pin, usart3_rx_pin),
-                serial::Config::default().baudrate(9600.bps()),
-                &clocks,
-            )
-            .unwrap();
-        let (_gps_tx, mut gps_rx) = gps_serial.split();
-        gps_rx.listen();
-
-        let gps_buf = ctx.local.gps_buf;
-        let (gps_buf_prod, gps_buf_cons) = gps_buf.split();
+        let shared = Shared { gps };
+        let local = Local { delay, led };
+        let monotonics = init::Monotonics(mono);
 
         blink::spawn().unwrap();
 
-        let local = Local {
-            gps_rx,
-            gps_buf_prod,
-            gps_buf_cons,
-            led,
-        };
-        let shared = Shared {};
-        let monotonics = init::Monotonics(mono);
         (shared, local, monotonics)
     }
 
-    #[idle(local = [gps_buf_cons])]
+    #[idle(local = [delay], shared = [gps])]
     fn idle(ctx: idle::Context) -> ! {
         defmt::info!("Started idle task");
-        let gps_buf_cons = ctx.local.gps_buf_cons;
 
-        let mut msg_buf: Vec<u8, 128> = Vec::new();
+        let _delay = ctx.local.delay;
+
         loop {
-            if let Some(b) = gps_buf_cons.dequeue() {
-                msg_buf.push(b).expect("Message buffer overflow");
-
-                if b == b'\n' {
-                    defmt::info!("{=[u8]:a}", &msg_buf);
-                    msg_buf.clear();
-                }
-            }
+            rtic::export::nop()
         }
     }
 
-    /// USART3 interrupt handler that reads data into the gps working buffer
-    #[task(binds = USART3, local = [gps_rx, gps_buf_prod])]
-    fn gps_irq(ctx: gps_irq::Context) {
-        let gps_rx = ctx.local.gps_rx;
-        let gps_buf_prod = ctx.local.gps_buf_prod;
+    #[task(shared = [gps])]
+    fn log_nmea(ctx: log_nmea::Context) {
+        let mut gps = ctx.shared.gps;
+        let msg = gps.lock(|gps| gps.last_nmea()).unwrap();
+        defmt::info!("{=[u8]:a}", &msg);
+    }
 
-        let b = gps_rx.read().unwrap();
-        gps_buf_prod.enqueue(b).unwrap();
+    /// USART3 interrupt handler that reads data into the gps working buffer
+    #[task(binds = USART3, shared = [gps])]
+    fn gps_irq(ctx: gps_irq::Context) {
+        let mut gps = ctx.shared.gps;
+        let b = gps.lock(|gps| gps.read_uart()).unwrap();
+        if b == b'\n' {
+            log_nmea::spawn().unwrap();
+        }
     }
 
     /// Toggles led every second


### PR DESCRIPTION
# Summary
Adds a device driver package `cansat-gps` that simplifies the code in our binary package `cansat-stm32f446`.

# Motivation
We should strive to move as much code as possible into non-binary crates to achieve greater portability.

# Design notes
This PR also creates a `log_nmea` task that prints new gps messages that is spawned from the uart handler each time we read a msg terminator ('\n').