### PR TITLE
Added error module

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -364,6 +364,7 @@ version = "0.3.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7ab17bb279def6720d058cb6c052249938e7f99260ab534879281a95367a87e5"
 dependencies = [
+ "defmt",
  "gcd",
 ]
 
@@ -733,6 +734,7 @@ dependencies = [
  "bitflags",
  "cortex-m",
  "cortex-m-rt",
+ "defmt",
  "embedded-dma",
  "embedded-hal 0.2.7",
  "embedded-hal 1.0.0-alpha.8",

--- a/cansat-stm32f446/Cargo.toml
+++ b/cansat-stm32f446/Cargo.toml
@@ -17,7 +17,7 @@ cortex-m-rt = "0.7.2"
 cortex-m-rtic = "1.1.3"
 defmt = "0.3.2"
 defmt-rtt = "0.4.0"
-stm32f4xx-hal = { version = "0.14.0", features = ["stm32f446", "rtic"] }
+stm32f4xx-hal = { version = "0.14.0", features = ["stm32f446", "rtic", "defmt"] }
 panic-probe = { version = "0.3.0", features = ["print-defmt"] }
 once_cell = { version = "1.16.0", default-features = false }
 heapless = { version = "0.7.16", features = ["defmt"] }

--- a/cansat-stm32f446/src/error.rs
+++ b/cansat-stm32f446/src/error.rs
@@ -1,0 +1,87 @@
+//! Error reporting utilities such as [`Report`], [`Error`] and [`WrapErr`].
+//!
+//! This module is a `nostd` alternative to [eyre](https://docs.rs/eyre/latest/eyre/index.html) crate.
+//!
+//! # Examples
+//! [`WrapErr`] extends the [`Result<T, E>`] type with an [`wrap_err`][WrapErr::wrap_err] method
+//! that maps it's `E` type into the [`error::Report`][Report]. `E` has to implement [`Into<error::Error>`] trait.
+//! ```
+//! use error::WrapErr;
+//!
+//! fn init() -> Result<(), error::Report> {
+//!     let sensor = Sensor::new().wrap_err("Failed to initialize sensor")?;
+//!     sensor.measure().wrap_err("Failed to measure using sensor")?;
+//!     Ok(())
+//! }
+//! ```
+
+use stm32f4xx_hal::{i2c, serial::config::InvalidConfig};
+
+/// Extension trait for [`Result`] that maps the error to [`Report`].
+///
+/// # Examples
+/// ```
+/// init().wrap_err("Initialization failed")?;
+/// ```
+pub trait WrapErr<T, E> {
+    fn wrap_err(self, description: &'static str) -> Result<T, Report>;
+}
+
+impl<T, E: Into<Error>> WrapErr<T, E> for Result<T, E> {
+    fn wrap_err(self, description: &'static str) -> Result<T, Report> {
+        self.map_err(|e| Report {
+            description,
+            cause: e.into(),
+        })
+    }
+}
+
+/// Error report consisting of an description and an [`Error`].
+#[derive(Debug)]
+pub struct Report {
+    pub description: &'static str,
+    pub cause: Error,
+}
+
+impl<E: Into<Error>> From<E> for Report {
+    fn from(e: E) -> Self {
+        Report {
+            description: "",
+            cause: e.into(),
+        }
+    }
+}
+
+impl defmt::Format for Report {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        defmt::write!(f, "{}\n    Caused by: {}", self.description, self.cause);
+    }
+}
+
+/// Aggregate for all the possible errors.
+#[derive(Debug)]
+pub enum Error {
+    Bme280(bme280::Error<i2c::Error>),
+    SerialConfig(InvalidConfig),
+}
+
+impl defmt::Format for Error {
+    fn format(&self, f: defmt::Formatter<'_>) {
+        match self {
+            Error::Bme280(e) => defmt::write!(f, "Bme280 failure - {}", defmt::Debug2Format(e)),
+            Error::SerialConfig(_) => defmt::write!(f, "Invalid serial configuration"),
+        }
+    }
+}
+
+impl From<bme280::Error<i2c::Error>> for Error {
+    fn from(e: bme280::Error<i2c::Error>) -> Self {
+        Error::Bme280(e)
+    }
+}
+
+impl From<InvalidConfig> for Error {
+    fn from(e: InvalidConfig) -> Self {
+        Error::SerialConfig(e)
+    }
+}


### PR DESCRIPTION
This PR aims to streamline error reporting. It introduces an `error` modules that provides `Report` and `Error` types as well as an `WrapErr` trait.

# Design notes
The module is very similar to [eyre](https://docs.rs/eyre/latest/eyre/) crate, but without any dynamic allocations. See their docs more examples.

`Report` is a struct that consists of a `description` and an `error`. Hopefully the `error` already contains some kind of message, the `description` serves as a way to provide additional context.

`Error` is simply an enum aggregate that can hold every possible error in our application

`WrapErr` extends `Result<T, E>` with additional method that can easily convert it to `Result<T, Report>`