### PR TITLE
main cleanup

### DIFF
--- a/cansat-stm32f446/src/error.rs
+++ b/cansat-stm32f446/src/error.rs
@@ -63,6 +63,7 @@ impl defmt::Format for Report {
 pub enum Error {
     Bme280(bme280::Error<i2c::Error>),
     SerialConfig(InvalidConfig),
+    Sdmmc(embedded_sdmmc::Error<embedded_sdmmc::SdMmcError>),
 }
 
 impl defmt::Format for Error {
@@ -70,6 +71,7 @@ impl defmt::Format for Error {
         match self {
             Error::Bme280(e) => defmt::write!(f, "Bme280 failure - {}", defmt::Debug2Format(e)),
             Error::SerialConfig(_) => defmt::write!(f, "Invalid serial configuration"),
+            Error::Sdmmc(e) => defmt::write!(f, "Sdmmc failure - {}", e),
         }
     }
 }
@@ -83,5 +85,17 @@ impl From<bme280::Error<i2c::Error>> for Error {
 impl From<InvalidConfig> for Error {
     fn from(e: InvalidConfig) -> Self {
         Error::SerialConfig(e)
+    }
+}
+
+impl From<embedded_sdmmc::Error<embedded_sdmmc::SdMmcError>> for Error {
+    fn from(e: embedded_sdmmc::Error<embedded_sdmmc::SdMmcError>) -> Self {
+        Error::Sdmmc(e)
+    }
+}
+
+impl From<embedded_sdmmc::SdMmcError> for Error {
+    fn from(e: embedded_sdmmc::SdMmcError) -> Self {
+        Error::Sdmmc(embedded_sdmmc::Error::DeviceError(e))
     }
 }

--- a/cansat-stm32f446/src/main.rs
+++ b/cansat-stm32f446/src/main.rs
@@ -4,78 +4,100 @@
 #![no_std]
 
 mod error;
+mod tasks;
 
 use defmt_rtt as _;
+use error::{Report, WrapErr};
+use heapless::String;
 use panic_probe as _;
+use stm32f4xx_hal::{
+    gpio, i2c, pac,
+    prelude::*,
+    serial, spi,
+    timer::{monotonic::MonoTimerUs, DelayUs},
+};
+use tasks::*;
+
+type Led = gpio::PA5<gpio::Output>;
+
+type Scl1 = gpio::PB6<gpio::Alternate<4, gpio::OpenDrain>>;
+type Sda1 = gpio::PB7<gpio::Alternate<4, gpio::OpenDrain>>;
+type I2c1 = i2c::I2c1<(Scl1, Sda1)>;
+type Bme280 = bme280::i2c::BME280<I2c1>;
+
+type Rx3 = gpio::PC10<gpio::Alternate<7>>;
+type Tx3 = gpio::PC11<gpio::Alternate<7>>;
+type Serial3 = serial::Serial3<(Rx3, Tx3)>;
+type Gps = cansat_gps::Gps<Serial3>;
+
+type Sck1 = gpio::PB3<gpio::Alternate<5>>;
+type Miso1 = gpio::PA6<gpio::Alternate<5>>;
+type Mosi1 = gpio::PA7<gpio::Alternate<5>>;
+type Spi1 = spi::Spi1<(Sck1, Miso1, Mosi1)>;
+type Cs1 = gpio::PA15<gpio::Output>;
+type SpiDevice1 = embedded_sdmmc::SdMmcSpi<Spi1, Cs1>;
+type BlockSpi1 = embedded_sdmmc::BlockSpi<'static, Spi1, Cs1>;
+const MAX_DIRS: usize = 4;
+const MAX_FILES: usize = 4;
+type SdmmcController = embedded_sdmmc::Controller<BlockSpi1, DummyClock, MAX_DIRS, MAX_FILES>;
+
+/// Maximal length supported by embedded_sdmmc
+const MAX_FILENAME_LEN: usize = 11;
+
+pub struct DummyClock;
+
+impl embedded_sdmmc::TimeSource for DummyClock {
+    fn get_timestamp(&self) -> embedded_sdmmc::Timestamp {
+        embedded_sdmmc::Timestamp {
+            year_since_1970: 0,
+            zero_indexed_month: 0,
+            zero_indexed_day: 0,
+            hours: 0,
+            minutes: 0,
+            seconds: 0,
+        }
+    }
+}
 
 #[rtic::app(device = stm32f4xx_hal::pac, dispatchers = [EXTI0])]
 mod app {
-    use super::error::{Report, WrapErr};
-    use bme280::i2c::BME280;
-    use cansat_gps::Gps;
-    use core::fmt::Write;
-    use cortex_m::asm;
-    use defmt::Debug2Format;
-    use embedded_sdmmc::{BlockSpi, Controller, SdMmcSpi, TimeSource, Timestamp};
-    use heapless::String;
-    use stm32f4xx_hal::{
-        gpio::{Alternate, OpenDrain, Output, Pin, PA5, PB6, PB7, PC10, PC11},
-        i2c::{self, DutyCycle, I2c1},
-        pac::{self, TIM3},
-        prelude::*,
-        serial::{self, Event, Serial3},
-        spi::{Phase, Polarity, Spi1},
-        timer::{monotonic::MonoTimerUs, DelayUs},
-    };
-
-    pub struct Clock;
-
-    impl TimeSource for Clock {
-        fn get_timestamp(&self) -> Timestamp {
-            Timestamp {
-                year_since_1970: 0,
-                zero_indexed_month: 0,
-                zero_indexed_day: 0,
-                hours: 0,
-                minutes: 0,
-                seconds: 0,
-            }
-        }
-    }
-
-    type Scl = PB6<Alternate<4, OpenDrain>>;
-    type Sda = PB7<Alternate<4, OpenDrain>>;
-
-    type Rx3 = PC10<Alternate<7>>;
-    type Tx3 = PC11<Alternate<7>>;
-
-    type Sck1 = Pin<'B', 3, Alternate<5>>;
-    type Miso1 = Pin<'A', 6, Alternate<5>>;
-    type Mosi1 = Pin<'A', 7, Alternate<5>>;
-    type Cs1 = Pin<'A', 15, Output>;
-    type BlockSpi1<'a> = BlockSpi<'a, Spi1<(Sck1, Miso1, Mosi1)>, Cs1>;
-
-    /// Maximal length supported by embedded_sdmmc
-    const MAX_FILENAME_LEN: usize = 11;
+    use super::*;
 
     #[shared]
     struct Shared {
-        gps: Gps<Serial3<(Rx3, Tx3)>>,
+        gps: Gps,
     }
 
     #[local]
     struct Local {
-        delay: DelayUs<TIM3>,
-        led: PA5<Output>,
-        bme280: BME280<I2c1<(Scl, Sda)>>,
-        controller: Controller<BlockSpi1<'static>, Clock, 4, 4>,
+        delay: DelayUs<pac::TIM3>,
+        led: Led,
+        bme280: Bme280,
+        controller: SdmmcController,
         filename: String<MAX_FILENAME_LEN>,
     }
 
     #[monotonic(binds = TIM2, default = true)]
     type MicrosecMono = MonoTimerUs<pac::TIM2>;
 
-    #[init(local = [spi_dev: Option<SdMmcSpi<Spi1<(Sck1, Miso1, Mosi1)>, Cs1>> = None])]
+    extern "Rust" {
+        #[task(shared = [gps])]
+        fn log_nmea(ctx: log_nmea::Context);
+
+        #[task(binds = USART3, shared = [gps])]
+        fn gps_irq(ctx: gps_irq::Context);
+
+        #[task(local = [led])]
+        fn blink(ctx: blink::Context);
+
+        #[task(local = [delay, bme280])]
+        fn bme_measure(ctx: bme_measure::Context);
+
+        #[task(local = [controller, filename])]
+        fn sdmmc_log(ctx: sdmmc_log::Context, filename: String<MAX_FILENAME_LEN>);
+    }
+
+    #[init(local = [spi_device1: Option<SpiDevice1> = None])]
     fn init(ctx: init::Context) -> (Shared, Local, init::Monotonics) {
         try_init(ctx).unwrap_or_else(|e| {
             defmt::panic!("Initialization failed: {}", e);
@@ -98,25 +120,24 @@ mod app {
         let led = gpioa.pa5.into_push_pull_output();
 
         let bme280 = {
-            let i2c_scl = gpiob
-                .pb6
-                .into_alternate()
-                .internal_pull_up(false)
-                .set_open_drain();
-            let i2c_sda = gpiob
-                .pb7
-                .into_alternate()
-                .internal_pull_up(false)
-                .set_open_drain();
-            let i2c = device.I2C1.i2c(
-                (i2c_scl, i2c_sda),
-                i2c::Mode::Fast {
+            let i2c1 = {
+                let scl1 = gpiob
+                    .pb6
+                    .into_alternate()
+                    .internal_pull_up(false)
+                    .set_open_drain();
+                let sda1 = gpiob
+                    .pb7
+                    .into_alternate()
+                    .internal_pull_up(false)
+                    .set_open_drain();
+                let mode = i2c::Mode::Fast {
                     frequency: 400000.Hz(),
-                    duty_cycle: DutyCycle::Ratio2to1,
-                },
-                &clocks,
-            );
-            let mut bme280 = BME280::new_primary(i2c);
+                    duty_cycle: i2c::DutyCycle::Ratio2to1,
+                };
+                device.I2C1.i2c((scl1, sda1), mode, &clocks)
+            };
+            let mut bme280 = Bme280::new_primary(i2c1);
             #[cfg(feature = "bme")]
             bme280
                 .init(&mut delay)
@@ -125,61 +146,70 @@ mod app {
         };
 
         let gps = {
-            let usart3_tx_pin = gpioc.pc10.into_alternate();
-            let usart3_rx_pin = gpioc.pc11.into_alternate();
-            let mut gps_serial = device
-                .USART3
-                .serial(
-                    (usart3_tx_pin, usart3_rx_pin),
-                    serial::Config::default().baudrate(9600.bps()),
-                    &clocks,
-                )
-                .wrap_err("Failed to create USART3")?;
-            gps_serial.listen(Event::Rxne);
-            Gps::new(gps_serial)
+            let mut usart3 = {
+                let tx3 = gpioc.pc10.into_alternate();
+                let rx3 = gpioc.pc11.into_alternate();
+                let config = serial::Config::default().baudrate(9600.bps());
+                device
+                    .USART3
+                    .serial((tx3, rx3), config, &clocks)
+                    .wrap_err("Failed to create USART3")?
+            };
+            usart3.listen(serial::Event::Rxne);
+            Gps::new(usart3)
         };
 
-        let spi1_device = {
-            let sck1 = gpiob.pb3.into_alternate();
-            let miso1 = gpioa.pa6.into_alternate();
-            let mosi1 = gpioa.pa7.into_alternate();
-            let cs1 = gpioa.pa15.into_push_pull_output();
-            let spi1 = device.SPI1.spi(
-                (sck1, miso1, mosi1),
-                stm32f4xx_hal::spi::Mode {
-                    polarity: Polarity::IdleLow,
-                    phase: Phase::CaptureOnFirstTransition,
-                },
-                400000.Hz(),
-                &clocks,
-            );
-            embedded_sdmmc::SdMmcSpi::new(spi1, cs1)
+        let mut controller = {
+            let spi_device1 = ctx.local.spi_device1;
+            *spi_device1 = Some({
+                let spi1 = {
+                    let sck1 = gpiob.pb3.into_alternate();
+                    let miso1 = gpioa.pa6.into_alternate();
+                    let mosi1 = gpioa.pa7.into_alternate();
+                    let mode = spi::Mode {
+                        polarity: spi::Polarity::IdleLow,
+                        phase: spi::Phase::CaptureOnFirstTransition,
+                    };
+                    device
+                        .SPI1
+                        .spi((sck1, miso1, mosi1), mode, 400000.Hz(), &clocks)
+                };
+                let cs1 = gpioa.pa15.into_push_pull_output();
+                embedded_sdmmc::SdMmcSpi::new(spi1, cs1)
+            });
+            let block_spi1 = spi_device1
+                .as_mut()
+                .unwrap()
+                .acquire()
+                .wrap_err("Failed to acquire block spi")?;
+            SdmmcController::new(block_spi1, DummyClock)
         };
 
-        *ctx.local.spi_dev = Some(spi1_device);
-        let mut controller = match ctx.local.spi_dev.as_mut().unwrap().acquire() {
-            Ok(sdmmc_spi) => Controller::new(sdmmc_spi, Clock),
-            Err(e) => {
-                defmt::panic!("Failed to create sdmmc controller: {}", e);
-            }
+        let filename = {
+            let volume = controller
+                .get_volume(embedded_sdmmc::VolumeIdx(0))
+                .wrap_err("Failed to get volume")?;
+            let root_dir = controller.open_root_dir(&volume).unwrap();
+
+            let mut log_count = 0;
+            controller
+                .iterate_dir(&volume, &root_dir, |_| {
+                    log_count += 1;
+                })
+                .wrap_err("Failed to iterate directory")?;
+            controller.close_dir(&volume, root_dir);
+
+            let mut filename = String::from(log_count);
+            filename
+                .push_str("_log.txt")
+                .expect("Filename buffer overflow");
+            filename
         };
 
-        let volume = match controller.get_volume(embedded_sdmmc::VolumeIdx(0)) {
-            Ok(volume) => volume,
-            Err(e) => defmt::panic!("Failed to get volume: {}", e),
-        };
-        let root_dir = controller.open_root_dir(&volume).unwrap();
-
-        let mut log_count = 0;
-        controller
-            .iterate_dir(&volume, &root_dir, |_| {
-                log_count += 1;
-            })
-            .unwrap();
-        let mut filename = String::from(log_count);
-        write!(filename, "_log.txt").unwrap();
         defmt::info!("Filename: {}", filename.as_str());
-        controller.close_dir(&volume, root_dir);
+
+        blink::spawn().unwrap();
+        sdmmc_log::spawn("Logs dump here ".into()).unwrap();
 
         let shared = Shared { gps };
         let local = Local {
@@ -190,93 +220,7 @@ mod app {
             filename,
         };
         let monotonics = init::Monotonics(mono);
-        blink::spawn().unwrap();
-        sdmmc_log::spawn("Logs dump here ".into()).unwrap();
 
         Ok((shared, local, monotonics))
-    }
-
-    #[idle]
-    fn idle(_ctx: idle::Context) -> ! {
-        defmt::info!("Started idle task");
-        loop {
-            asm::nop();
-        }
-    }
-
-    #[task(shared = [gps])]
-    fn log_nmea(ctx: log_nmea::Context) {
-        let mut gps = ctx.shared.gps;
-        let msg = gps.lock(|gps| gps.last_nmea()).unwrap();
-        defmt::info!("{=[u8]:a}", &msg);
-    }
-
-    /// USART3 interrupt handler that reads data into the gps working buffer
-    #[task(binds = USART3, shared = [gps])]
-    fn gps_irq(ctx: gps_irq::Context) {
-        let mut gps = ctx.shared.gps;
-        let (_, is_terminator) = gps.lock(|gps| gps.read_uart()).unwrap();
-        if is_terminator {
-            log_nmea::spawn().unwrap();
-        }
-    }
-
-    /// Toggles led every second
-    #[task(local = [led])]
-    fn blink(ctx: blink::Context) {
-        let led = ctx.local.led;
-        led.toggle();
-        defmt::debug!("Blink");
-        blink::spawn_after(1.secs()).unwrap();
-    }
-
-    #[task(local = [delay, bme280])]
-    fn bme_measure(ctx: bme_measure::Context) {
-        #[cfg(feature = "bme")]
-        {
-            let bme280 = ctx.local.bme280;
-            let delay = ctx.local.delay;
-            let measurements = match bme280.measure(delay) {
-                Ok(m) => m,
-                Err(e) => {
-                    defmt::error!("Could not read bme280 measurements: {}", Debug2Format(&e));
-                    return;
-                }
-            };
-            let altitude = cansat::calculate_altitude(measurements.pressure);
-            defmt::info!("Altitude = {} meters above sea level", altitude);
-            defmt::info!("Relative Humidity = {}%", measurements.humidity);
-            defmt::info!("Temperature = {} deg C", measurements.temperature);
-            defmt::info!("Pressure = {} pascals", measurements.pressure);
-
-            bme_measure::spawn_after(5.secs()).unwrap();
-        }
-    }
-    #[task(local = [controller, filename])]
-    fn sdmmc_log(ctx: sdmmc_log::Context, log_string: String<MAX_FILENAME_LEN>) {
-        let controller = ctx.local.controller;
-        let filename = ctx.local.filename;
-        let mut volume = match controller.get_volume(embedded_sdmmc::VolumeIdx(0)) {
-            Ok(volume) => volume,
-            Err(e) => defmt::panic!("Failed to get volume: {}", e),
-        };
-
-        let root_dir = controller.open_root_dir(&volume).unwrap();
-
-        let mut f = controller
-            .open_file_in_dir(
-                &mut volume,
-                &root_dir,
-                filename,
-                embedded_sdmmc::Mode::ReadWriteCreateOrAppend,
-            )
-            .unwrap();
-        let num_written = controller
-            .write(&mut volume, &mut f, log_string.as_bytes())
-            .unwrap();
-        defmt::info!("Written: {} bytes\n", num_written);
-        if let Err(e) = controller.close_file(&volume, f) {
-            defmt::panic!("Failed to close file: {}", e);
-        }
     }
 }

--- a/cansat-stm32f446/src/tasks.rs
+++ b/cansat-stm32f446/src/tasks.rs
@@ -1,0 +1,80 @@
+use super::{
+    app::{blink, bme_measure, gps_irq, log_nmea, sdmmc_log},
+    MAX_FILENAME_LEN,
+};
+use defmt::Debug2Format;
+use heapless::String;
+use rtic::Mutex;
+use stm32f4xx_hal::prelude::*;
+
+pub fn log_nmea(ctx: log_nmea::Context) {
+    let mut gps = ctx.shared.gps;
+    let msg = gps.lock(|gps| gps.last_nmea()).unwrap();
+    defmt::info!("{=[u8]:a}", &msg);
+}
+
+/// USART3 interrupt handler that reads data into the gps working buffer
+pub fn gps_irq(ctx: gps_irq::Context) {
+    let mut gps = ctx.shared.gps;
+    let (_, is_terminator) = gps.lock(|gps| gps.read_uart()).unwrap();
+    if is_terminator {
+        log_nmea::spawn().unwrap();
+    }
+}
+
+/// Toggles led every second
+pub fn blink(ctx: blink::Context) {
+    let led = ctx.local.led;
+    led.toggle();
+    defmt::debug!("Blink");
+    blink::spawn_after(1.secs()).unwrap();
+}
+
+pub fn bme_measure(ctx: bme_measure::Context) {
+    #[cfg(feature = "bme")]
+    {
+        let bme = ctx.local.bme280;
+        let delay = ctx.local.delay;
+        let measurements = match bme.measure(delay) {
+            Ok(m) => m,
+            Err(e) => {
+                defmt::error!("Could not read bme280 measurements: {}", Debug2Format(&e));
+                return;
+            }
+        };
+        let altitude = cansat::calculate_altitude(measurements.pressure);
+        defmt::info!("Altitude = {} meters above sea level", altitude);
+        defmt::info!("Relative Humidity = {}%", measurements.humidity);
+        defmt::info!("Temperature = {} deg C", measurements.temperature);
+        defmt::info!("Pressure = {} pascals", measurements.pressure);
+
+        bme_measure::spawn_after(5.secs()).unwrap();
+    }
+}
+
+pub fn sdmmc_log(ctx: sdmmc_log::Context, log_string: String<MAX_FILENAME_LEN>) {
+    let controller = ctx.local.controller;
+    let filename = ctx.local.filename;
+    let mut volume = match controller.get_volume(embedded_sdmmc::VolumeIdx(0)) {
+        Ok(volume) => volume,
+        Err(e) => defmt::panic!("Failed to get volume: {}", e),
+    };
+
+    let root_dir = controller.open_root_dir(&volume).unwrap();
+
+    let mut f = controller
+        .open_file_in_dir(
+            &mut volume,
+            &root_dir,
+            filename,
+            embedded_sdmmc::Mode::ReadWriteCreateOrAppend,
+        )
+        .unwrap();
+    let num_written = controller
+        .write(&mut volume, &mut f, log_string.as_bytes())
+        .unwrap();
+    defmt::info!("Written: {} bytes\n", num_written);
+    if let Err(e) = controller.close_file(&volume, f) {
+        defmt::panic!("Failed to close file: {}", e);
+    }
+}


### PR DESCRIPTION
Working inside the rtic app macro is a bit of a pain, so I tried to extract as much stuff as possible. Once caveat, `Local` and `Shared` structs are private for some reason, thus I decided to leave `try_init` inside the macro until it is fixed in rtic