### PR TITLE
Configure GPS

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -86,6 +86,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bef38d45163c2f1dde094a7dfd33ccf595c92905c8f8f4fdc18d06fb1037718a"
 
 [[package]]
+name = "bitflags"
+version = "2.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "24a6904aef64d73cf10ab17ebace7befb918b82164785cb89907993be7f83813"
+
+[[package]]
 name = "bme280"
 version = "0.4.4"
 source = "git+https://github.com/grupacosmo/bme280-rs#19f4c95db6f86f75fd312a891a7e35bd70b4ef60"
@@ -187,7 +193,7 @@ version = "4.0.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7db700bc935f9e43e88d00b0850dae18a63773cfbec6d8e070fccf7fef89a39"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "clap_derive",
  "clap_lex",
  "is-terminal",
@@ -257,9 +263,9 @@ dependencies = [
 
 [[package]]
 name = "cortex-m-rt"
-version = "0.7.2"
+version = "0.7.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6d3328b8b5534f0c90acd66b68950f2763b37e0173cac4d8b4937c4a80761f9"
+checksum = "ee84e813d593101b1723e13ec38b6ab6abbdbaaa4546553f5395ed274079ddb1"
 dependencies = [
  "cortex-m-rt-macros",
 ]
@@ -324,7 +330,7 @@ version = "0.3.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "956673bd3cb347512bf988d1e8d89ac9a82b64f6eec54d3c01c3529dac019882"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "defmt-macros",
 ]
 
@@ -396,7 +402,7 @@ version = "1.0.0-alpha.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c3babfc7fd332142a0b11aebf592992f211f4e01b6222fb04b03aba1bd80018d"
 dependencies = [
- "nb 1.0.0",
+ "nb 1.1.0",
 ]
 
 [[package]]
@@ -464,7 +470,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d9607bfc4c388f9d629704f56ede4a007546cad417b3bcd6fc7c87dc7edce04a"
 dependencies = [
  "fugit",
- "nb 1.0.0",
+ "nb 1.1.0",
 ]
 
 [[package]]
@@ -687,14 +693,17 @@ version = "0.1.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "801d31da0513b6ec5214e9bf433a77966320625a37860f910be265be6e18d06f"
 dependencies = [
- "nb 1.0.0",
+ "nb 1.1.0",
 ]
 
 [[package]]
 name = "nb"
-version = "1.0.0"
+version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "546c37ac5d9e56f55e73b677106873d9d9f5190605e41a856503623648488cae"
+checksum = "8d5439c4ad607c3c23abf66de8c8bf57ba8adcd1f129e699851a6e43935d339d"
+dependencies = [
+ "defmt",
+]
 
 [[package]]
 name = "num_enum"
@@ -873,7 +882,7 @@ version = "0.36.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4feacf7db682c6c329c4ede12649cd36ecab0f3be5b7d74e6a20304725db4549"
 dependencies = [
- "bitflags",
+ "bitflags 1.3.2",
  "errno",
  "io-lifetimes",
  "libc",
@@ -989,12 +998,12 @@ dependencies = [
 
 [[package]]
 name = "stm32f4xx-hal"
-version = "0.14.0"
+version = "0.16.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dbb045e607d0946eca27523141d192d7ee91aea0dff9736be100b8fc0c186abf"
+checksum = "431cd6045c6644beb39d421a37967e7f0708bce98ed6e38559137e09d5ae6d81"
 dependencies = [
  "bare-metal 1.0.0",
- "bitflags",
+ "bitflags 2.2.1",
  "cortex-m 0.7.7",
  "cortex-m-rt",
  "defmt",
@@ -1004,7 +1013,7 @@ dependencies = [
  "embedded-storage",
  "fugit",
  "fugit-timer",
- "nb 1.0.0",
+ "nb 1.1.0",
  "rand_core",
  "rtic-monotonic",
  "stm32f4",

--- a/crates/cansat-core/src/measurements.rs
+++ b/crates/cansat-core/src/measurements.rs
@@ -14,7 +14,7 @@ pub struct Measurements {
     #[serde(serialize_with = "option_distance_meters")]
     pub altitude: Option<Distance>,
 
-    pub nmea: Option<Bytes<82>>,
+    pub nmea: Option<Bytes<256>>,
 
     #[serde(serialize_with = "option_vector_i16x3")]
     pub acceleration: Option<vector::I16x3>,
@@ -78,14 +78,16 @@ impl defmt::Format for Measurements {
         defmt::write!(
             fmt,
             "temp: {} °C, pres: {} hPa, alt: {} m, accel: {}, orient: {}, nmea: {=[u8]:a}",
-            self.temperature.unwrap_or_default().as_celsius(),
+            self.temperature
+                .unwrap_or(Temperature::from_celsius(0.0))
+                .as_celsius(),
             self.pressure.unwrap_or_default().as_hectos(),
             self.altitude.unwrap_or_default().as_meters(),
             self.acceleration
                 .map(|v| (v.x, v.y, v.z))
                 .unwrap_or_default(),
             self.orientation.as_ref().map(defmt::Debug2Format),
-            self.nmea.as_ref().map(|v| &v[..]).unwrap_or(&[])
+            self.nmea.as_ref().unwrap_or(&Bytes::new())
         );
     }
 }

--- a/crates/cansat-core/src/measurements.rs
+++ b/crates/cansat-core/src/measurements.rs
@@ -77,17 +77,57 @@ impl defmt::Format for Measurements {
     fn format(&self, fmt: defmt::Formatter) {
         defmt::write!(
             fmt,
-            "temp: {} °C, pres: {} hPa, alt: {} m, accel: {}, orient: {}, nmea: {=[u8]:a}",
-            self.temperature
-                .unwrap_or(Temperature::from_celsius(0.0))
-                .as_celsius(),
-            self.pressure.unwrap_or_default().as_hectos(),
-            self.altitude.unwrap_or_default().as_meters(),
-            self.acceleration
-                .map(|v| (v.x, v.y, v.z))
-                .unwrap_or_default(),
-            self.orientation.as_ref().map(defmt::Debug2Format),
-            self.nmea.as_ref().unwrap_or(&Bytes::new())
+            "temp: {}, pres: {}, alt: {}, accel: {}, orient: {}, nmea: {}",
+            OrError(&self.temperature.map(Celsius)),
+            OrError(&self.pressure.map(HectoPascals)),
+            OrError(&self.altitude.map(Meters)),
+            OrError(&self.acceleration.map(|v| (v.x, v.y, v.z))),
+            OrError(&self.orientation.as_ref().map(defmt::Debug2Format)),
+            OrError(&self.nmea.as_ref().map(|v| Ascii(v)))
         );
+    }
+}
+
+struct Celsius(pub Temperature);
+
+impl defmt::Format for Celsius {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{} °C", self.0.as_celsius());
+    }
+}
+
+struct HectoPascals(pub Pressure);
+
+impl defmt::Format for HectoPascals {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{} hPa", self.0.as_hectos());
+    }
+}
+
+struct Meters(pub Distance);
+
+impl defmt::Format for Meters {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{} m", self.0.as_meters());
+    }
+}
+
+struct Ascii<'a>(pub &'a [u8]);
+
+impl<'a> defmt::Format for Ascii<'a> {
+    fn format(&self, fmt: defmt::Formatter) {
+        defmt::write!(fmt, "{=[u8]:a}", self.0);
+    }
+}
+
+struct OrError<'a, T>(pub &'a Option<T>);
+
+impl<'a, T: defmt::Format> defmt::Format for OrError<'a, T> {
+    fn format(&self, fmt: defmt::Formatter) {
+        if let Some(v) = self.0 {
+            defmt::write!(fmt, "{}", v);
+        } else {
+            defmt::write!(fmt, "ERROR");
+        }
     }
 }

--- a/crates/cansat-core/src/quantity.rs
+++ b/crates/cansat-core/src/quantity.rs
@@ -30,7 +30,7 @@ impl core::ops::Div for Pressure {
     }
 }
 
-#[derive(Default, PartialEq, Clone, Copy, PartialOrd, Add, Sub, Mul, Div)]
+#[derive(PartialEq, Clone, Copy, PartialOrd, Add, Sub, Mul, Div)]
 pub struct Temperature(f32);
 
 impl Temperature {

--- a/crates/cansat-gps/src/lib.rs
+++ b/crates/cansat-gps/src/lib.rs
@@ -8,8 +8,10 @@ use double_buf::DoubleBuf;
 use embedded_hal::{nb, serial};
 use heapless::Vec;
 
-/// Maximum length of an NMEA message including $ and [CR][LF].
-pub const MAX_NMEA_LEN: usize = 256;
+/// Maximum length of a standard NMEA message including $ and [CR][LF].
+///
+/// Note that not all messages adhere to this standard, for example GGA.
+pub const STANDARD_MAX_NMEA_LEN: usize = 82;
 
 /// Gps driver.
 ///

--- a/crates/cansat-gps/src/lib.rs
+++ b/crates/cansat-gps/src/lib.rs
@@ -21,8 +21,9 @@ pub const MAX_NMEA_LEN: usize = 256;
 /// # use cansat_test_utils::mock;
 /// # let uart = cansat_test_utils::mock::Serial::new([b'\r', b'\n']);
 /// use cansat_gps::Gps;
+/// use heapless::Vec;
 ///
-/// let mut gps = Gps::new(uart);
+/// let mut gps: Gps<_, 82> = Gps::new(uart);
 ///
 /// let msg = loop {
 ///     let (b, is_new_msg) = gps.read_serial().unwrap();

--- a/crates/cansat-gps/tests/main.rs
+++ b/crates/cansat-gps/tests/main.rs
@@ -8,7 +8,7 @@ const SECOND_MSG: &[u8] = b"$GPGLL,,,,,080619.00,V,N*4C\r\n";
 #[test]
 fn gps_last_nmea_returns_none_if_no_msg_received() {
     let uart = mock::Serial::new(FIRST_MSG.to_owned());
-    let mut gps = Gps::new(uart);
+    let mut gps: Gps<_, 82> = Gps::new(uart);
 
     gps.read_serial().unwrap();
     gps.read_serial().unwrap();
@@ -19,7 +19,7 @@ fn gps_last_nmea_returns_none_if_no_msg_received() {
 #[test]
 fn gps_last_nmea_returns_msg_if_msg_received() {
     let uart = mock::Serial::new(FIRST_MSG.to_owned());
-    let mut gps = Gps::new(uart);
+    let mut gps: Gps<_, 82> = Gps::new(uart);
 
     while let (_, _is_msg_terminated @ false) = gps.read_serial().unwrap() {}
 
@@ -29,7 +29,7 @@ fn gps_last_nmea_returns_msg_if_msg_received() {
 #[test]
 fn gps_last_nmea_returns_first_msg_if_second_not_yet_terminated() {
     let uart = mock::Serial::new([FIRST_MSG, SECOND_MSG].concat());
-    let mut gps = Gps::new(uart);
+    let mut gps: Gps<_, 82> = Gps::new(uart);
     let mut rng = rand::thread_rng();
 
     while let (_, _is_msg_terminated @ false) = gps.read_serial().unwrap() {}
@@ -44,7 +44,7 @@ fn gps_last_nmea_returns_first_msg_if_second_not_yet_terminated() {
 #[test]
 fn gps_last_nmea_returns_second_read_msg() {
     let uart = mock::Serial::new([FIRST_MSG, SECOND_MSG].concat());
-    let mut gps = Gps::new(uart);
+    let mut gps: Gps<_, 82> = Gps::new(uart);
 
     while let (_, _is_msg_terminated @ false) = gps.read_serial().unwrap() {}
     while let (_, _is_msg_terminated @ false) = gps.read_serial().unwrap() {}

--- a/crates/cansat-stm32f4/Cargo.toml
+++ b/crates/cansat-stm32f4/Cargo.toml
@@ -18,7 +18,7 @@ cortex-m-rt = "0.7.2"
 cortex-m-rtic = "1.1.3"
 defmt = "0.3.4"
 defmt-rtt = "0.4.0"
-stm32f4xx-hal = { version = "0.14.0", features = ["stm32f411", "rtic", "defmt"] }
+stm32f4xx-hal = { version = "0.16.0", features = ["stm32f411", "rtic", "defmt"] }
 panic-probe = { version = "0.3.0", features = ["print-defmt"], optional = true }
 once_cell = { version = "1.16.0", default-features = false }
 heapless = { version = "0.7.16", features = ["defmt"] }

--- a/crates/cansat-stm32f4/src/startup.rs
+++ b/crates/cansat-stm32f4/src/startup.rs
@@ -11,7 +11,8 @@ use tap::prelude::*;
 pub type Monotonic = MonoTimerUs<pac::TIM2>;
 pub type Delay = DelayUs<pac::TIM3>;
 pub type Led = gpio::PC13<gpio::Output>;
-pub type Gps = cansat_gps::Gps<Serial1>;
+pub type Gps = cansat_gps::Gps<Serial1, 256>;
+pub type GpsError = cansat_gps::Error<stm32f4xx_hal::serial::Error>;
 pub type SdmmcController =
     embedded_sdmmc::Controller<BlockSpi2, DummyClock, MAX_OPEN_DIRS, MAX_OPEN_FILES>;
 pub type SdmmcError = embedded_sdmmc::Error<embedded_sdmmc::SdMmcError>;
@@ -80,16 +81,15 @@ impl Statik {
 
 #[derive(Debug)]
 pub enum Error {
-    ConsumingDevices,
+    CriticalDevice,
 }
 
 impl defmt::Format for Error {
     fn format(&self, fmt: defmt::Formatter) {
         match self {
-            Self::ConsumingDevices => defmt::write!(
-                fmt,
-                "Failed to initialize all the consuming peripheral devices"
-            ),
+            Self::CriticalDevice => {
+                defmt::write!(fmt, "Failed to initialize a critical peripheral device")
+            }
         }
     }
 }
@@ -106,7 +106,7 @@ pub fn init_drivers(mut board: Board, statik: &'static mut Statik) -> Result<Can
 
     // TODO: append `&& lora.is_none()` to the condition
     if sd_logger.is_none() {
-        return Err(Error::ConsumingDevices);
+        return Err(Error::CriticalDevice);
     }
 
     let bme280 = init_bme280(shared_i2c1.acquire_i2c(), &mut board.delay)
@@ -118,7 +118,10 @@ pub fn init_drivers(mut board: Board, statik: &'static mut Statik) -> Result<Can
         .ok();
     let tracker = accelerometer::Tracker::new(3700.0);
 
-    let gps = init_gps(board.serial1);
+    let gps = init_gps(board.serial1).map_err(|e| {
+        defmt::error!("Failed to initialize GPS: {}", defmt::Debug2Format(&e));
+        Error::CriticalDevice
+    })?;
 
     Ok(CanSat {
         monotonic: board.monotonic,
@@ -138,7 +141,10 @@ fn init_sd_logger(spi: Spi2, cs: Cs2, statik: &'static mut Statik) -> Result<SdL
     let spi_device = statik.spi2_device.as_mut().unwrap();
     let block_spi = spi_device.acquire().map_err(SdmmcError::DeviceError)?;
     let controller = SdmmcController::new(block_spi, DummyClock);
-    SdLogger::new(controller)
+    let mut logger = SdLogger::new(controller)?;
+    // controller does some long initialization on first write
+    logger.write(b"\n")?;
+    Ok(logger)
 }
 
 fn init_bme280(i2c: I2c1Proxy, delay: &mut Delay) -> Result<Bme280, Bme280Error> {
@@ -149,11 +155,31 @@ fn init_bme280(i2c: I2c1Proxy, delay: &mut Delay) -> Result<Bme280, Bme280Error>
     Ok(bme280)
 }
 
-fn init_gps(mut serial: Serial1) -> Gps {
+fn init_gps(mut serial: Serial1) -> Result<Gps, GpsError> {
     defmt::info!("Initializing GPS");
 
     serial.listen(serial::Event::Rxne);
-    Gps::new(serial)
+    let mut gps = Gps::new(serial);
+
+    let set_gll_output_rate = b"$PUBX,40,GLL,0,0,0,0,0,0*5C\r\n";
+    gps.send(set_gll_output_rate)?;
+
+    let set_gsa_output_rate = b"$PUBX,40,GSA,0,0,0,0,0,0*4E\r\n";
+    gps.send(set_gsa_output_rate)?;
+
+    let set_gsv_output_rate = b"$PUBX,40,GSV,0,0,0,0,0,0*59\r\n";
+    gps.send(set_gsv_output_rate)?;
+
+    let set_gga_output_rate = b"$PUBX,40,GGA,0,1,0,0,0,0*5B\r\n";
+    gps.send(set_gga_output_rate)?;
+
+    let set_vtg_output_rate = b"$PUBX,40,VTG,0,0,0,0,0,0*5E\r\n";
+    gps.send(set_vtg_output_rate)?;
+
+    let set_rmc_output_rate = b"$PUBX,40,RMC,0,0,0,0,0,0*47\r\n";
+    gps.send(set_rmc_output_rate)?;
+
+    Ok(gps)
 }
 
 fn init_lis3dh(i2c: I2c1Proxy) -> Result<Lis3dh, Lis3dhError> {

--- a/crates/cansat-stm32f4/src/startup.rs
+++ b/crates/cansat-stm32f4/src/startup.rs
@@ -1,9 +1,13 @@
 use crate::SdLogger;
 use core::convert::Infallible;
 use stm32f4xx_hal::{
-    gpio, i2c::{self, I2c1}, pac,
+    gpio,
+    i2c::{self, I2c1},
+    pac,
     prelude::*,
-    serial, spi::{self, Spi2}, serial::Serial1,
+    serial,
+    serial::Serial1,
+    spi::{self, Spi2},
     timer::{monotonic::MonoTimerUs, DelayUs},
 };
 use tap::prelude::*;

--- a/crates/cansat-stm32f4/src/startup.rs
+++ b/crates/cansat-stm32f4/src/startup.rs
@@ -1,9 +1,9 @@
 use crate::SdLogger;
 use core::convert::Infallible;
 use stm32f4xx_hal::{
-    gpio, i2c, pac,
+    gpio, i2c::{self, I2c1}, pac,
     prelude::*,
-    serial, spi,
+    serial, spi::{self, Spi2}, serial::Serial1,
     timer::{monotonic::MonoTimerUs, DelayUs},
 };
 use tap::prelude::*;
@@ -22,24 +22,11 @@ pub type Bme280 = bme280::i2c::BME280<I2c1Proxy>;
 pub type Bme280Error = bme280::Error<i2c::Error>;
 
 type BlockSpi2 = embedded_sdmmc::BlockSpi<'static, Spi2, Cs2>;
+type Spi2Device = embedded_sdmmc::SdMmcSpi<Spi2, Cs2>;
+type Cs2 = gpio::PB12<gpio::Output>;
 const MAX_OPEN_DIRS: usize = 4;
 const MAX_OPEN_FILES: usize = 4;
-
 type I2c1Proxy = shared_bus::I2cProxy<'static, shared_bus::AtomicCheckMutex<I2c1>>;
-type I2c1 = i2c::I2c1<(Scl1, Sda1)>;
-type Scl1 = gpio::PB8<gpio::Alternate<4, gpio::OpenDrain>>;
-type Sda1 = gpio::PB9<gpio::Alternate<4, gpio::OpenDrain>>;
-
-type Serial1 = serial::Serial1<(Tx1, Rx1)>;
-type Tx1 = gpio::PB6<gpio::Alternate<7>>;
-type Rx1 = gpio::PB7<gpio::Alternate<7>>;
-
-type Spi2Device = embedded_sdmmc::SdMmcSpi<Spi2, Cs2>;
-type Spi2 = spi::Spi2<(Sck2, Miso2, Mosi2)>;
-type Cs2 = gpio::PB12<gpio::Output>;
-type Sck2 = gpio::PB13<gpio::Alternate<5>>;
-type Miso2 = gpio::PB14<gpio::Alternate<5>>;
-type Mosi2 = gpio::PB15<gpio::Alternate<5>>;
 
 pub struct CanSat {
     pub monotonic: Monotonic,


### PR DESCRIPTION
* Configure output rates of NMEA messages using ublox's proprietary PBUX NMEA messages, eg. `$PUBX,40,GGA,0,1,0,0,0,0*5B`. GGA is setup so that it is sent on each epoch and all the other messages are disabled. Refer to [ublox specification](https://content.u-blox.com/sites/default/files/products/documents/u-blox7-V14_ReceiverDescriptionProtocolSpec_%28GPS.G7-SW-12001%29_Public.pdf) for details, specifically sections 25.3 and 29.
* Add generic MAX_NMEA_LEN argument to Gps. It turns out that some devices implement messages that do not adhere to the standard 82 characters limit.
* Bump `stm32f4xx_hal` to 0.16
* Remove Default from Temperature. It really shouldn't impl Default as it is not obvious what the default value should be, considering that the type handles both, Celsius and Kelvins.