### PR TITLE
Updated accelerometer's tracker

### DIFF
--- a/crates/cansat-stm32f4/src/startup.rs
+++ b/crates/cansat-stm32f4/src/startup.rs
@@ -112,7 +112,7 @@ pub fn init_drivers(mut board: Board, statik: &'static mut Statik) -> Result<Can
     let lis3dh = init_lis3dh(shared_i2c1.acquire_i2c())
         .tap_err(|e| defmt::error!("Failed to initialize LIS3DH: {}", defmt::Debug2Format(&e)))
         .ok();
-    let tracker = accelerometer::Tracker::new(3700.0);
+    let tracker = accelerometer::Tracker::new(3932.0);
 
     let gps = init_gps(board.serial1).map_err(|e| {
         defmt::error!("Failed to initialize GPS: {}", defmt::Debug2Format(&e));


### PR DESCRIPTION
As the threshold value should be slightly less than the absolute value of the reading we get from the accelerometer when the device is lying in a position where two out of the three axes  (x,y,z) are reading 0, the search initiation value of 3952.0 was determined based on the results of testing all six possible orientations where the most frequent results were: (0,0,4016) FaceDown
(0,0,-4128) FaceUp
(-4080,0,0) LandscapeDown
(4016,0,0) LandscapeUp
(0,-4032,0) PortraitDown
(0,3952,0) PortraitUp

Further testing proved that the threshold set at 3932.0 offers accurate information regarding orientation.