### PR TITLE
Implement deserialize for Measurements

### DIFF
--- a/crates/cansat-core/src/measurements.rs
+++ b/crates/cansat-core/src/measurements.rs
@@ -21,13 +21,15 @@ pub struct Measurements {
     pub nmea: Option<NmeaGga>,
 
     #[serde(serialize_with = "option_vector_f32x3")]
-    #[serde(serialize_with = "option_vector_f32x3_deserialize")]
+    #[serde(deserialize_with = "option_vector_f32x3_deserialize")]
     pub acceleration: Option<vector::F32x3>,
 
     #[serde(serialize_with = "option_vector_f32x3")]
+    #[serde(deserialize_with = "option_vector_f32x3_deserialize")]
     pub gyro: Option<vector::F32x3>,
 
     #[serde(serialize_with = "option_vector_f32x2")]
+    #[serde(deserialize_with = "option_vector_f32x2_deserialize")]
     pub rollpitch: Option<vector::F32x2>,
 }
 

--- a/crates/cansat-core/src/measurements.rs
+++ b/crates/cansat-core/src/measurements.rs
@@ -47,7 +47,7 @@ where
     D: Deserializer<'de>,
 {
     let temperature: Option<f32> = de::Deserialize::deserialize(deserializer)?;
-    return Ok(temperature.map(Temperature::from_celsius));
+    Ok(temperature.map(Temperature::from_celsius))
 }
 
 fn option_pressure_pascals<S>(v: &Option<Pressure>, s: S) -> Result<S::Ok, S::Error>
@@ -64,7 +64,7 @@ where
     D: Deserializer<'de>,
 {
     let pressure: Option<f32> = de::Deserialize::deserialize(deserializer)?;
-    return Ok(pressure.map(Pressure::from_pascals));
+    Ok(pressure.map(Pressure::from_pascals))
 }
 
 fn option_distance_meters<S>(v: &Option<Distance>, s: S) -> Result<S::Ok, S::Error>
@@ -79,7 +79,7 @@ where
     D: Deserializer<'de>,
 {
     let distance: Option<f32> = de::Deserialize::deserialize(deserializer)?;
-    return Ok(distance.map(Distance::from_meters));
+    Ok(distance.map(Distance::from_meters))
 }
 
 fn option_vector_f32x2<S>(v: &Option<vector::F32x2>, serializer: S) -> Result<S::Ok, S::Error>
@@ -97,7 +97,7 @@ where
     D: Deserializer<'de>,
 {
     let opt: Option<(f32, f32)> = de::Deserialize::deserialize(deserializer)?;
-    return Ok(opt.map(|(x, y)| vector::F32x2::new(x, y)));
+    Ok(opt.map(|(x, y)| vector::F32x2::new(x, y)))
 }
 
 fn option_vector_f32x3<S>(v: &Option<vector::F32x3>, serializer: S) -> Result<S::Ok, S::Error>
@@ -115,7 +115,7 @@ where
     D: Deserializer<'de>,
 {
     let opt: Option<(f32, f32, f32)> = de::Deserialize::deserialize(deserializer)?;
-    return Ok(opt.map(|(x, y, z)| vector::F32x3::new(x, y, z)));
+    Ok(opt.map(|(x, y, z)| vector::F32x3::new(x, y, z)))
 }
 
 #[cfg(feature = "defmt")]

--- a/crates/cansat-core/src/measurements.rs
+++ b/crates/cansat-core/src/measurements.rs
@@ -7,29 +7,29 @@ use serde::{de, Deserializer, Serialize};
 #[derive(Default, serde::Serialize, serde::Deserialize)]
 pub struct Measurements {
     #[serde(serialize_with = "option_temperature_celsius")]
-    #[serde(deserialize_with = "option_temperature_celsius_deserialize")]
+    #[serde(deserialize_with = "f32_as_optional_temperature_in_celcius")]
     pub temperature: Option<Temperature>,
 
     #[serde(serialize_with = "option_pressure_pascals")]
-    #[serde(deserialize_with = "option_pressure_pascals_deserialize")]
+    #[serde(deserialize_with = "f32_as_optional_pressure_in_pascals")]
     pub pressure: Option<Pressure>,
 
     #[serde(serialize_with = "option_distance_meters")]
-    #[serde(deserialize_with = "option_distance_meters_deserialize")]
+    #[serde(deserialize_with = "f32_as_optional_distance_in_meters")]
     pub altitude: Option<Distance>,
 
     pub nmea: Option<NmeaGga>,
 
     #[serde(serialize_with = "option_vector_f32x3")]
-    #[serde(deserialize_with = "option_vector_f32x3_deserialize")]
+    #[serde(deserialize_with = "touple_as_vector_f32x3")]
     pub acceleration: Option<vector::F32x3>,
 
     #[serde(serialize_with = "option_vector_f32x3")]
-    #[serde(deserialize_with = "option_vector_f32x3_deserialize")]
+    #[serde(deserialize_with = "touple_as_vector_f32x3")]
     pub gyro: Option<vector::F32x3>,
 
     #[serde(serialize_with = "option_vector_f32x2")]
-    #[serde(deserialize_with = "option_vector_f32x2_deserialize")]
+    #[serde(deserialize_with = "touple_as_vector_f32x2")]
     pub rollpitch: Option<vector::F32x2>,
 }
 
@@ -40,7 +40,7 @@ where
     v.map(|v| v.as_celsius()).serialize(s)
 }
 
-fn option_temperature_celsius_deserialize<'de, D>(
+fn f32_as_optional_temperature_in_celcius<'de, D>(
     deserializer: D,
 ) -> Result<Option<Temperature>, D::Error>
 where
@@ -57,7 +57,7 @@ where
     v.map(|v| v.as_pascals()).serialize(s)
 }
 
-fn option_pressure_pascals_deserialize<'de, D>(
+fn f32_as_optional_pressure_in_pascals<'de, D>(
     deserializer: D,
 ) -> Result<Option<Pressure>, D::Error>
 where
@@ -74,7 +74,7 @@ where
     v.map(|v| v.as_meters()).serialize(s)
 }
 
-fn option_distance_meters_deserialize<'de, D>(deserializer: D) -> Result<Option<Distance>, D::Error>
+fn f32_as_optional_distance_in_meters<'de, D>(deserializer: D) -> Result<Option<Distance>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -92,9 +92,7 @@ where
     }
 }
 
-fn option_vector_f32x2_deserialize<'de, D>(
-    deserializer: D,
-) -> Result<Option<vector::F32x2>, D::Error>
+fn touple_as_vector_f32x2<'de, D>(deserializer: D) -> Result<Option<vector::F32x2>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -112,9 +110,7 @@ where
     }
 }
 
-fn option_vector_f32x3_deserialize<'de, D>(
-    deserializer: D,
-) -> Result<Option<vector::F32x3>, D::Error>
+fn touple_as_vector_f32x3<'de, D>(deserializer: D) -> Result<Option<vector::F32x3>, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/crates/cansat-core/src/measurements.rs
+++ b/crates/cansat-core/src/measurements.rs
@@ -21,15 +21,15 @@ pub struct Measurements {
     pub nmea: Option<NmeaGga>,
 
     #[serde(serialize_with = "option_vector_f32x3")]
-    #[serde(deserialize_with = "touple_as_vector_f32x3")]
+    #[serde(deserialize_with = "tuple_as_vector_f32x3")]
     pub acceleration: Option<vector::F32x3>,
 
     #[serde(serialize_with = "option_vector_f32x3")]
-    #[serde(deserialize_with = "touple_as_vector_f32x3")]
+    #[serde(deserialize_with = "tuple_as_vector_f32x3")]
     pub gyro: Option<vector::F32x3>,
 
     #[serde(serialize_with = "option_vector_f32x2")]
-    #[serde(deserialize_with = "touple_as_vector_f32x2")]
+    #[serde(deserialize_with = "tuple_as_vector_f32x2")]
     pub rollpitch: Option<vector::F32x2>,
 }
 
@@ -92,7 +92,7 @@ where
     }
 }
 
-fn touple_as_vector_f32x2<'de, D>(deserializer: D) -> Result<Option<vector::F32x2>, D::Error>
+fn tuple_as_vector_f32x2<'de, D>(deserializer: D) -> Result<Option<vector::F32x2>, D::Error>
 where
     D: Deserializer<'de>,
 {
@@ -110,7 +110,7 @@ where
     }
 }
 
-fn touple_as_vector_f32x3<'de, D>(deserializer: D) -> Result<Option<vector::F32x3>, D::Error>
+fn tuple_as_vector_f32x3<'de, D>(deserializer: D) -> Result<Option<vector::F32x3>, D::Error>
 where
     D: Deserializer<'de>,
 {

--- a/crates/cansat-core/src/nmea.rs
+++ b/crates/cansat-core/src/nmea.rs
@@ -13,7 +13,7 @@ pub enum Error<'a> {
 }
 
 #[derive(Serialize, Deserialize, Debug)]
-pub struct NmeaGga(GgaData);
+pub struct NmeaGga(pub GgaData);
 
 impl NmeaGga {
     pub fn try_new(bytes: &[u8]) -> Result<NmeaGga, Error> {
@@ -29,10 +29,6 @@ impl NmeaGga {
             .fix_type
             .map(|ft| FixType::Invalid != ft)
             .unwrap_or(false)
-    }
-
-    pub fn get_data(&self) -> &GgaData {
-        &self.0
     }
 }
 

--- a/crates/cansat-core/src/nmea.rs
+++ b/crates/cansat-core/src/nmea.rs
@@ -30,6 +30,10 @@ impl NmeaGga {
             .map(|ft| FixType::Invalid != ft)
             .unwrap_or(false)
     }
+
+    pub fn get_data(&self) -> &GgaData {
+        &self.0
+    }
 }
 
 #[cfg(feature = "defmt")]

--- a/crates/cansat-core/src/nmea.rs
+++ b/crates/cansat-core/src/nmea.rs
@@ -1,6 +1,6 @@
 use nmea::sentences::{FixType, GgaData};
 use nmea::ParseResult;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 
 #[cfg(feature = "defmt")]
 use defmt::Format;
@@ -12,7 +12,7 @@ pub enum Error<'a> {
     InvalidCommand,
 }
 
-#[derive(Serialize, Debug)]
+#[derive(Serialize, Deserialize, Debug)]
 pub struct NmeaGga(GgaData);
 
 impl NmeaGga {


### PR DESCRIPTION
To avoid code repetition it'll be very useful to have Deserialize trait implemented on the Measurements struct.